### PR TITLE
Add AJAX based pagination to about us page

### DIFF
--- a/aboutus/aboutus_sub01.html
+++ b/aboutus/aboutus_sub01.html
@@ -173,7 +173,10 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
                                     <div class="list_con">
                                         <ul>
                                             <?php
-                                            $aboutusImages = $db->query("SELECT * FROM df_site_aboutus_images ORDER BY prior DESC limit 4");
+                                            $aboutusImagesAll = $db->query("SELECT * FROM df_site_aboutus_images ORDER BY prior DESC");
+                                            $totalImages      = count($aboutusImagesAll);
+                                            $totalPages       = ceil($totalImages / 4);
+                                            $aboutusImages    = array_slice($aboutusImagesAll, 0, 4);
                                             foreach ($aboutusImages as $i => $img) { ?>
                                                 <li>
                                                     <a href="javascript:aboutus_sub01_info03_popup(<?php echo $i; ?>);">
@@ -188,7 +191,7 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
                                         </ul>
                                     </div>
 
-                                    <div class="number_list_con">
+                                    <div class="number_list_con" data-total-pages="<?php echo $totalPages; ?>">
                                         <div class="contents_con">
                                             <div class="btn_con">
                                                 <a href="#">
@@ -207,8 +210,8 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
                                                     01
                                                 </a>
 
-                                                <a href="#" class="list_a">
-                                                    04
+                                                <a href="#" class="list_a last_page_num">
+                                                    <?php echo sprintf('%02d', $totalPages); ?>
                                                 </a>
 
                                                 <div class="bar"></div>
@@ -245,7 +248,7 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
                                         <div class="slide_con">
                                             <div class="swiper aboutus_sub01_info03_popup_slide">
                                                 <div class="swiper-wrapper">
-                                                    <?php foreach ($aboutusImages as $img) { ?>
+                                                    <?php foreach ($aboutusImagesAll as $img) { ?>
                                                         <div class="swiper-slide aboutus_sub01_info03_popup_slide_div">
                                                             <div class="img_con"
                                                                 style="background-image:url('/userfiles/images/<?php echo $img['upfile_pc']; ?>');">
@@ -273,7 +276,7 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
                                         <div class="thumbnail_slide_con">
                                             <div class="swiper aboutus_sub01_info03_popup_thumbnail_slide">
                                                 <div class="swiper-wrapper">
-                                                    <?php foreach ($aboutusImages as $img) { ?>
+                                                    <?php foreach ($aboutusImagesAll as $img) { ?>
                                                         <div
                                                             class="swiper-slide aboutus_sub01_info03_popup_thumbnail_slide_div">
                                                             <div class="img_con"
@@ -576,6 +579,47 @@ include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
         }, 500);
 
         ScrollTrigger.refresh();
+    });
+</script>
+
+<script type="text/javascript">
+    $(function () {
+        var currentPage = 1;
+        var $numCon = $(".aboutus_sub01_con > .contents_con > .info03_con > .contents_con > .contents_con > .list_con > .number_list_con");
+        var totalPages = parseInt($numCon.data("total-pages"), 10) || 1;
+
+        function zeroPad(n) {
+            return (n < 10 ? "0" : "") + n;
+        }
+
+        function loadPage(p) {
+            if (p < 1) p = 1;
+            if (p > totalPages) p = totalPages;
+            $.getJSON('/controller/aboutus_images.php', { page: p }, function (res) {
+                if (res.result === 'ok') {
+                    var html = '';
+                    $.each(res.items, function (i, item) {
+                        html += '<li>';
+                        html += '    <a href="javascript:aboutus_sub01_info03_popup(' + item.index + ');">';
+                        html += '        <div class="img_con" style="background-image:url(\'/userfiles/images/' + item.upfile_pc + '\');">';
+                        html += '            <img src="/img/aboutus/aboutus_sub01_info03_list_img_con_blank_img.png" alt="블랭크 이미지" class="fx" />';
+                        html += '        </div>';
+                        html += '    </a>';
+                        html += '</li>';
+                    });
+                    $numCon.siblings('.list_con').find('ul').html(html);
+                    currentPage = p;
+                }
+            });
+        }
+
+        $numCon.find('.btn_con').eq(0).find('a').eq(0).on('click', function (e) { e.preventDefault(); loadPage(1); });
+        $numCon.find('.btn_con').eq(0).find('a').eq(1).on('click', function (e) { e.preventDefault(); loadPage(currentPage - 1); });
+        $numCon.find('.btn_con').eq(1).find('a').eq(0).on('click', function (e) { e.preventDefault(); loadPage(currentPage + 1); });
+        $numCon.find('.btn_con').eq(1).find('a').eq(1).on('click', function (e) { e.preventDefault(); loadPage(totalPages); });
+
+        $numCon.find('.list_con .list_a').eq(0).text(zeroPad(1));
+        $numCon.find('.list_con .last_page_num').text(zeroPad(totalPages));
     });
 </script>
 

--- a/controller/aboutus_images.php
+++ b/controller/aboutus_images.php
@@ -1,0 +1,26 @@
+<?php
+include $_SERVER['DOCUMENT_ROOT'] . '/inc/global.inc';
+
+header('Content-Type: application/json; charset=utf-8');
+
+$page = isset($_GET['page']) ? max(1, intval($_GET['page'])) : 1;
+$perPage = 4;
+$offset = ($page - 1) * $perPage;
+
+$totalImages = $db->single("SELECT COUNT(*) FROM df_site_aboutus_images");
+$rows = $db->query("SELECT * FROM df_site_aboutus_images ORDER BY prior DESC LIMIT {$offset}, {$perPage}");
+
+$result = [];
+foreach ($rows as $i => $row) {
+    $result[] = [
+        'index' => $offset + $i,
+        'upfile_pc' => $row['upfile_pc']
+    ];
+}
+
+echo json_encode([
+    'result' => 'ok',
+    'items'  => $result,
+    'total'  => (int)$totalImages
+]);
+

--- a/kr/aboutus/aboutus_sub01.html
+++ b/kr/aboutus/aboutus_sub01.html
@@ -154,7 +154,10 @@
                                                                         <div class="list_con">
                                                                         <ul>
                                                                         <?php
-                                                                        $aboutusImages = $db->query("SELECT * FROM df_site_aboutus_images ORDER BY prior DESC");
+                                                                        $aboutusImagesAll = $db->query("SELECT * FROM df_site_aboutus_images ORDER BY prior DESC");
+                                                                        $totalImages      = count($aboutusImagesAll);
+                                                                        $totalPages       = ceil($totalImages / 4);
+                                                                        $aboutusImages    = array_slice($aboutusImagesAll, 0, 4);
                                                                         foreach ($aboutusImages as $i => $img) { ?>
                                                                         <li>
                                                                         <a href="javascript:aboutus_sub01_info03_popup(<?php echo $i; ?>);">
@@ -167,7 +170,7 @@
                                                                         </ul>
                                                                         </div>
 
-										<div class="number_list_con">
+                                                                               <div class="number_list_con" data-total-pages="<?php echo $totalPages; ?>">
 											<div class="contents_con">
 												<div class="btn_con">
 													<a href="#">
@@ -184,9 +187,9 @@
 														01
 													</a>
 
-													<a href="#" class="list_a">
-														04
-													</a>
+                                                                               <a href="#" class="list_a last_page_num">
+                                                                               <?php echo sprintf('%02d', $totalPages); ?>
+                                                                               </a>
 
 													<div class="bar"></div>
 												</div>
@@ -220,7 +223,7 @@
 											<div class="slide_con">
                                                                         <div class="swiper aboutus_sub01_info03_popup_slide">
                                                                         <div class="swiper-wrapper">
-                                                                        <?php foreach ($aboutusImages as $img) { ?>
+                                                                        <?php foreach ($aboutusImagesAll as $img) { ?>
                                                                         <div class="swiper-slide aboutus_sub01_info03_popup_slide_div">
                                                                         <div class="img_con" style="background-image:url('/userfiles/images/<?php echo $img['upfile_pc']; ?>');">
                                                                         <img src="/kr/img/aboutus/aboutus_sub01_info03_list_img_con_blank_img.png" alt="블랭크 이미지" class="fx" />
@@ -242,7 +245,7 @@
 											<div class="thumbnail_slide_con">
                                                                         <div class="swiper aboutus_sub01_info03_popup_thumbnail_slide">
                                                                         <div class="swiper-wrapper">
-                                                                        <?php foreach ($aboutusImages as $img) { ?>
+                                                                        <?php foreach ($aboutusImagesAll as $img) { ?>
                                                                         <div class="swiper-slide aboutus_sub01_info03_popup_thumbnail_slide_div">
                                                                         <div class="img_con" style="background-image:url('/userfiles/images/<?php echo $img['upfile_pc']; ?>');">
                                                                         <img src="/kr/img/aboutus/aboutus_sub01_info03_list_img_con_blank_img.png" alt="블랭크 이미지" class="fx" />
@@ -532,8 +535,47 @@
 			}, 500);
 
 			ScrollTrigger.refresh();
-		});
-	</script>
+                });
+        </script>
+
+        <script type="text/javascript">
+                $(function(){
+                        var currentPage = 1;
+                        var $numCon = $(".aboutus_sub01_con > .contents_con > .info03_con > .contents_con > .contents_con > .list_con > .number_list_con");
+                        var totalPages = parseInt($numCon.data("total-pages"), 10) || 1;
+
+                        function zeroPad(n){ return (n < 10 ? '0' : '') + n; }
+
+                        function loadPage(p){
+                                if(p < 1) p = 1;
+                                if(p > totalPages) p = totalPages;
+                                $.getJSON('/controller/aboutus_images.php', {page:p}, function(res){
+                                        if(res.result === 'ok'){
+                                                var html = '';
+                                                $.each(res.items, function(i,item){
+                                                        html += '<li>';
+                                                        html += '    <a href="javascript:aboutus_sub01_info03_popup(' + item.index + ');">';
+                                                        html += '        <div class="img_con" style="background-image:url(\'/userfiles/images/' + item.upfile_pc + '\');">';
+                                                        html += '            <img src="/kr/img/aboutus/aboutus_sub01_info03_list_img_con_blank_img.png" alt="블랭크 이미지" class="fx" />';
+                                                        html += '        </div>';
+                                                        html += '    </a>';
+                                                        html += '</li>';
+                                                });
+                                                $numCon.siblings('.list_con').find('ul').html(html);
+                                                currentPage = p;
+                                        }
+                                });
+                        }
+
+                        $numCon.find('.btn_con').eq(0).find('a').eq(0).on('click', function(e){e.preventDefault(); loadPage(1);});
+                        $numCon.find('.btn_con').eq(0).find('a').eq(1).on('click', function(e){e.preventDefault(); loadPage(currentPage-1);});
+                        $numCon.find('.btn_con').eq(1).find('a').eq(0).on('click', function(e){e.preventDefault(); loadPage(currentPage+1);});
+                        $numCon.find('.btn_con').eq(1).find('a').eq(1).on('click', function(e){e.preventDefault(); loadPage(totalPages);});
+
+                        $numCon.find('.list_con .list_a').eq(0).text(zeroPad(1));
+                        $numCon.find('.list_con .last_page_num').text(zeroPad(totalPages));
+                });
+        </script>
 
 	<script type="text/javascript" language="javascript">
 		// info03 팝업 열기/닫기
@@ -726,4 +768,4 @@
 
 <?php
 	include $_SERVER['DOCUMENT_ROOT'].'/kr/include/footer.html'; 
-?>	
+?>


### PR DESCRIPTION
## Summary
- enable AJAX paging for aboutus certification images
- support same feature for Korean page
- add endpoint `controller/aboutus_images.php` to serve image data

## Testing
- `php -l controller/aboutus_images.php`
- `php -l aboutus/aboutus_sub01.html`
- `php -l kr/aboutus/aboutus_sub01.html`

------
https://chatgpt.com/codex/tasks/task_e_687de67243a48322bd60eeddc676459d